### PR TITLE
Use the new Collection Interface AST

### DIFF
--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -8,56 +8,62 @@ jest.setTimeout(10000)
 const BASE_API_URL = process.env.E2E_API_URL ?? 'http://localhost:8080'
 const API_URL = `${BASE_API_URL}/v0`
 const wait = (time: number) => new Promise((resolve) => { setTimeout(resolve, time) })
-const createCollection = async (s: Polybase, namespace: string, extraFields?: string) => {
-  const collections = await s.applySchema(`
-    collection Col {
-      id: string;
-      name: string;
-      info: {
-        age: number;
-      };
-      aliases: string[];
-      balances: map<string, number>;
-      publicKey: string;
-      ${extraFields ?? ''}
 
-      @index(name);
+const defaultSchema = (extraFields?: string) => `
+@public
+collection Col {
+  id: string;
+  name: string;
+  info: {
+    age: number;
+  };
+  aliases: string[];
+  balances: map<string, number>;
+  publicKey: string;
+  ${extraFields ?? ''}
 
-      function constructor (id: string, name: string, age: number, aliases: string[], balances: map<string, number>) {
-        this.id = id;
-        this.name = name;
-        this.info = { age: age };
-        this.aliases = aliases;
-        this.balances = balances;
-        this.publicKey = ctx.publicKey;
-      }
+  @index(name);
 
-      function setName (name: string) {
-        this.name = name;
-      }
+  function constructor (id: string, name: string, age: number, aliases: string[], balances: map<string, number>) {
+    this.id = id;
+    this.name = name;
+    this.info = { age: age };
+    this.aliases = aliases;
+    this.balances = balances;
+    if (ctx.publicKey) this.publicKey = ctx.publicKey.toHex();
+    else this.publicKey = '';
+  }
 
-      function setNameWithAuth (name: string) {
-        if (this.publicKey != ctx.publicKey) {
-          error('you do not own this record');
-        }
-        this.name = name;
-      }
+  function setName (name: string) {
+    this.name = name;
+  }
 
-      function takeOtherCol(otherCol: OtherCol) {}
-
-      function destroy () {
-        selfdestruct();
-      }
+  function setNameWithAuth (name: string) {
+    if (this.publicKey != ctx.publicKey.toHex()) {
+      error('you do not own this record');
     }
+    this.name = name;
+  }
 
-    collection OtherCol {
-      id: string;
+  function takeOtherCol(otherCol: OtherCol) {}
 
-      function constructor (id: string) {
-        this.id = id;
-      }
-    }
-  `, namespace)
+  function destroy () {
+    selfdestruct();
+  }
+}
+
+@public
+collection OtherCol {
+  id: string;
+
+  function constructor (id: string) {
+    this.id = id;
+  }
+}
+`
+
+const createCollection = async (s: Polybase, namespace: string, schema?: string) => {
+  const collections = await s.applySchema(schema || defaultSchema(), namespace)
 
   return collections[0]
 }
@@ -481,7 +487,14 @@ test('signing', async () => {
   const c = await createCollection(s, namespace)
 
   const col = await s.collection('Collection').record(`${namespace}/Col`).get()
-  expect(col.data.publicKey).toEqual(expect.stringContaining('0x'))
+  expect(col.data.publicKey).toEqual({
+    kty: 'EC',
+    crv: 'secp256k1',
+    alg: 'ES256K',
+    use: 'sig',
+    x: expect.any(String),
+    y: expect.any(String),
+  })
 
   await c.create(['id1', 'Calum2', 20, [], {}])
 

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -53,7 +53,7 @@
   },
   "dependencies": {
     "@polybase/eth": "^0.3.22",
-    "@polybase/polylang": "0.4.4",
+    "@polybase/polylang": "^0.4.5",
     "axios": "0.27.2"
   }
 }

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -3,7 +3,6 @@ import { Query } from './Query'
 import { Subscription, SubscriptionFn, SubscriptionErrorFn } from './Subscription'
 import { Client } from './Client'
 import { BasicValue, CollectionMeta, CollectionRecordResponse, CollectionList, QueryWhereOperator, CallArgs } from './types'
-import { parse } from '@polybase/polylang'
 import { validateSet } from '@polybase/polylang/dist/validator'
 import { validateCallParameters, getCollectionAST } from './util'
 import { createError, PolybaseError } from './errors'
@@ -49,7 +48,7 @@ export class Collection<T> {
   private getValidator = async (): Promise<(data: Partial<T>) => Promise<boolean>> => {
     if (this.validator) return this.validator
     const meta = await this.getMeta()
-    const ast = await parse(meta.code)
+    const ast = JSON.parse(meta.ast)
     this.validator = async (data: Partial<T>) => {
       try {
         await validateSet(getCollectionAST(this.id, ast), data)
@@ -69,7 +68,7 @@ export class Collection<T> {
 
   create = async (args: CallArgs): Promise<CollectionRecordResponse<T>> => {
     const meta = await this.getMeta()
-    const ast = await parse(meta.code)
+    const ast = JSON.parse(meta.ast)
     validateCallParameters(this.id, 'constructor', ast, args)
 
     const res = await this.client.request({

--- a/packages/client/src/Polybase.ts
+++ b/packages/client/src/Polybase.ts
@@ -47,7 +47,7 @@ export class Polybase {
     return this.config.defaultNamespace ? `${this.config.defaultNamespace}/${path}` : path
   }
 
-  private setCollectionCode = async <T>(data: CollectionMeta): Promise<Collection<T>> => {
+  private setCollectionCode = async <T>(data: Pick<CollectionMeta, 'id' | 'code'>): Promise<Collection<T>> => {
     const id = data.id
     const col = this.collection('Collection')
 
@@ -71,12 +71,12 @@ export class Polybase {
   /* Applies the given schema to the database, creating new collections and adding existing collections  */
   applySchema = async (schema: string, namespace?: string): Promise<Collection<any>[]> => {
     const collections = []
-    const ast = await parse(schema)
-
     const ns = (namespace ?? this.config.defaultNamespace)
     if (!ns) {
       throw createError('collection/invalid-id', { message: 'Namespace is missing' })
     }
+
+    const [, root] = await parse(schema, ns)
 
     // We already manually prepend the namespace to the collection name,
     // so we need a client without a default namespace.
@@ -85,11 +85,11 @@ export class Polybase {
       defaultNamespace: undefined,
     })
 
-    for (const node of ast.nodes) {
-      if (!node.Collection) continue
+    for (const node of root) {
+      if (node.kind !== 'collection') continue
 
       collections.push(polybaseWithoutNamespace.setCollectionCode({
-        id: ns + '/' + node.Collection.name,
+        id: ns + '/' + node.name,
         code: schema,
       }))
     }

--- a/packages/client/src/Record.ts
+++ b/packages/client/src/Record.ts
@@ -1,4 +1,3 @@
-import { parse } from '@polybase/polylang'
 import { Collection } from './Collection'
 import { SubscriptionErrorFn, SubscriptionFn } from './Subscription'
 import { Client } from './Client'
@@ -22,7 +21,7 @@ export class CollectionRecord<T> {
 
   call = async (functionName: string, args: CallArgs = []): Promise<CollectionRecordResponse<T>> => {
     const meta = await this.collection.getMeta()
-    const ast = await parse(meta.code)
+    const ast = JSON.parse(meta.ast)
     validateCallParameters(this.collection.id, functionName, ast, args)
 
     const res = await this.client.request({

--- a/packages/client/src/__tests__/Collection.spec.ts
+++ b/packages/client/src/__tests__/Collection.spec.ts
@@ -3,6 +3,7 @@ import { CollectionRecord } from '../Record'
 import { Query } from '../Query'
 import { Client } from '../Client'
 import { defaultRequest } from './util'
+import { parse } from '@polybase/polylang'
 
 let sender: jest.Mock
 let signer: jest.Mock
@@ -39,6 +40,9 @@ test('get metadata - success', async () => {
     code: `
       collection col {}
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {}
+    `, ''))[1]),
   }
 
   sender.mockResolvedValue({
@@ -60,6 +64,11 @@ test('validate valid record', async () => {
         name: string;
       }
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {
+        name: string;
+      }
+    `, ''))[1]),
   }
 
   sender.mockResolvedValue({
@@ -81,6 +90,11 @@ test('validate invalid record', async () => {
         age: number;
       }  
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {
+        age: number;
+      }
+    `, ''))[1]),
   }
 
   sender.mockResolvedValue({
@@ -134,6 +148,17 @@ test('.create() sends a create request', async () => {
         }
       }
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {
+        id: string;
+        age?: number;
+
+        function constructor(id: string, age: number) {
+          this.id = id;
+          this.age = age;
+        }
+      }
+    `, ''))[1]),
   }
 
   sender.mockResolvedValueOnce({

--- a/packages/client/src/__tests__/Polybase.spec.ts
+++ b/packages/client/src/__tests__/Polybase.spec.ts
@@ -2,6 +2,7 @@ import { Polybase } from '../Polybase'
 import { Collection } from '../Collection'
 import { defaultRequest } from './util'
 import { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios'
+import { parse } from '@polybase/polylang'
 
 // const clock = FakeTimers.install()
 const baseURL = 'https://base.com/'
@@ -82,6 +83,7 @@ test('creates collections from schema in namespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })
@@ -92,6 +94,7 @@ test('creates collections from schema in namespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })
@@ -102,6 +105,7 @@ test('creates collections from schema in namespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })
@@ -230,6 +234,7 @@ test('creates collections from schema in defaultNamespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })
@@ -240,6 +245,7 @@ test('creates collections from schema in defaultNamespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })
@@ -250,6 +256,7 @@ test('creates collections from schema in defaultNamespace', async () => {
       data: {
         id: 'Collection',
         code: 'collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }',
+        ast: JSON.stringify((await parse('collection Collection { id: string; name?: string; lastRecordUpdated?: string; code?: string; publicKey?: string; constructor (id: string, code: string) { this.id = id; this.code = code; this.publicKey = ctx.publicKey; } updateCode (code: string) { if (this.publicKey != ctx.publicKey) { throw error(\'invalid owner\'); } this.code = code; } }', ''))[1]),
       },
     },
   })

--- a/packages/client/src/__tests__/Record.spec.ts
+++ b/packages/client/src/__tests__/Record.spec.ts
@@ -2,6 +2,7 @@ import { CollectionRecord } from '../Record'
 import { Collection } from '../Collection'
 import { Client } from '../Client'
 import { defaultRequest } from './util'
+import { parse } from '@polybase/polylang'
 
 let sender: jest.Mock
 let signer: jest.Mock
@@ -68,6 +69,15 @@ test('.call() sends a call request', async () => {
         }
       }
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {
+        age: number;
+
+        function setAge(age: number) {
+          this.age = age;
+        }
+      }
+    `, ''))[1]),
   }
 
   sender.mockResolvedValueOnce({
@@ -131,6 +141,15 @@ test('.call() works with boolean arguments', async () => {
         }
       }
     `,
+    ast: JSON.stringify((await parse(`
+      collection col {
+        isActive: boolean;
+
+        function setIsActive(isActive: boolean) {
+          this.isActive = isActive;
+        }
+      }
+    `, ''))[1]),
   }
 
   sender.mockResolvedValueOnce({

--- a/packages/client/src/types.ts
+++ b/packages/client/src/types.ts
@@ -20,6 +20,7 @@ export interface CollectionList<T> {
 export interface CollectionMeta {
   id: string
   code: string
+  ast: string
   lastRecordUpdated?: string
   publicKey?: string
 }

--- a/packages/client/src/util.ts
+++ b/packages/client/src/util.ts
@@ -1,34 +1,40 @@
-import { Program, Collection } from '@polybase/polylang'
 import { CollectionRecord } from './Record'
 import type { CallArgs } from './types'
 
-export function validateCallParameters (collectionId: string, functionName: string, ast: Program, args: CallArgs) {
-  const funcAST = getCollectionAST(collectionId, ast).items.find((f: any) => f?.Function?.name === functionName)?.Function
+export function validateCallParameters (collectionId: string, functionName: string, ast: any, args: CallArgs) {
+  const funcAST = getCollectionAST(collectionId, ast).attributes.find((f: any) => f.kind === 'method' && f.name === functionName)
   if (!funcAST) throw new Error('Function not found')
 
-  for (const param in funcAST.parameters) {
-    const ourArg = args[param as any]
-    const expectedType = funcAST.parameters[param as any].type_
-    switch (expectedType) {
-      case 'String':
-        if (typeof ourArg !== 'string') throw new Error(`Argument ${param} must be a string`)
+  let i = 0
+  for (const attr of funcAST.attributes) {
+    if (attr.kind !== 'parameter') continue
+    const param = i++
+
+    const ourArg = args[param]
+    const expectedType = attr.type
+    switch (expectedType.kind) {
+      case 'primitive':
+        switch (expectedType.value) {
+          case 'string':
+            if (typeof ourArg !== 'string') throw new Error(`Argument ${param} must be a string`)
+            break
+          case 'number':
+            if (typeof ourArg !== 'number') throw new Error(`Argument ${param} must be a number`)
+            break
+          case 'boolean':
+            if (typeof ourArg !== 'boolean') throw new Error(`Argument ${param} must be a boolean`)
+        }
         break
-      case 'Number':
-        if (typeof ourArg !== 'number') throw new Error(`Argument ${param} must be a number`)
-        break
-      case 'Boolean':
-        if (typeof ourArg !== 'boolean') throw new Error(`Argument ${param} must be a boolean`)
-        break
-      case 'Record':
+      case 'record':
         if (!(ourArg && typeof ourArg === 'object' && ourArg instanceof CollectionRecord)) throw new Error(`Argument ${param} must be a record`)
         break
     }
   }
 }
 
-export function getCollectionAST (id: string, ast: Program): Collection {
+export function getCollectionAST (id: string, ast: any): any {
   const name = getCollectionShortNameFromId(id)
-  return ast.nodes.find(c => c.Collection?.name === name)?.Collection
+  return ast.filter((n: any) => n.kind === 'collection').find((n: any) => n.name === name)
 }
 
 export function getCollectionShortNameFromId (id: string) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1762,10 +1762,10 @@
   dependencies:
     esquery "^1.0.1"
 
-"@polybase/polylang@0.4.4":
-  version "0.4.4"
-  resolved "https://registry.yarnpkg.com/@polybase/polylang/-/polylang-0.4.4.tgz#d5a02621af9d1716ca63cab358618cde7519c8e1"
-  integrity sha512-FADipju/wlBKdEeS4xcf85fcW0U+9OwehdYVkq7xNIjEz3DClaT0bQqQoVqmUGn1wMxmXqA1wSvsk9/aEuwzAQ==
+"@polybase/polylang@^0.4.5":
+  version "0.4.5"
+  resolved "https://registry.yarnpkg.com/@polybase/polylang/-/polylang-0.4.5.tgz#2191f1bbfb34891bab77ed3be3f69d7d51c4af73"
+  integrity sha512-CRatgyh5GbI/ATNUGp7eU1DEPWz2WTc6wIDrPID/katnT1r8PDdbHZB5hl22FoyBBWaMkzNhvxlheJIAc0Sk3Q==
 
 "@sinclair/typebox@^0.24.1":
   version "0.24.51"
@@ -1989,18 +1989,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/lodash.merge@^4.6.7":
-  version "4.6.7"
-  resolved "https://registry.yarnpkg.com/@types/lodash.merge/-/lodash.merge-4.6.7.tgz#0af6555dd8bc6568ef73e5e0d820a027362946b1"
-  integrity sha512-OwxUJ9E50gw3LnAefSHJPHaBLGEKmQBQ7CZe/xflHkyy/wH2zVyEIAKReHvVrrn7zKdF58p16We9kMfh7v0RRQ==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.182"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.182.tgz#05301a4d5e62963227eaafe0ce04dd77c54ea5c2"
-  integrity sha512-/THyiqyQAP9AfARo4pF+aCGcyiQ94tX/Is2I7HofNRqoYLgN1PBoOWu2/zTA5zMxzP5EFutMtWtGAFRKUe961Q==
 
 "@types/minimatch@^3.0.3":
   version "3.0.5"


### PR DESCRIPTION
Before merging this we need to merge https://github.com/polybase/polylang/pull/59 and update polylang version.

We still need to parse code for `applySchema` to get the collections and their names from the user's schema.

CI fails (needs upgraded polylang dependency), but all tests are passing for me locally, including E2E tests.

Depends on https://github.com/polybase/polybase/pull/284