### PR TITLE
Check read permission to send and cache read signatures

### DIFF
--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -507,6 +507,12 @@ collection PrivateCol {
     x: expect.any(String),
     y: expect.any(String),
   })
+
+  s.signer((d: string) => {
+    throw new Error('Signer should not be called')
+  })
+  const record2 = await c.record('id1').get()
+  expect(record2.data.id).toEqual('id1')
 })
 
 test('signing', async () => {

--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -1,6 +1,6 @@
 import { encodeToString, secp256k1, stripPublicKeyPrefix } from '@polybase/util'
 import { ethPersonalSign } from '@polybase/eth'
-import { Polybase, Collection } from '../src'
+import { Polybase, Collection, PublicKey } from '../src'
 import { getPublicKey } from '@polybase/util/dist/algorithems/secp256k1'
 
 jest.setTimeout(10000)
@@ -464,6 +464,48 @@ test('list data with cursor', async () => {
         hash: expect.stringMatching(/^./),
       },
     }],
+  })
+})
+
+test('read access', async () => {
+  const namespace = `${prefix}-read-access`
+  const pv = await secp256k1.generatePrivateKey()
+
+  s = new Polybase({
+    baseURL: API_URL,
+    signer: async (d: string) => {
+      const sig = ethPersonalSign(pv, d)
+      return {
+        sig,
+        h: 'eth-personal-sign',
+      }
+    },
+  })
+
+  const c: Collection<{ id: string, publicKey: PublicKey }> = await createCollection(s, namespace, `
+collection PrivateCol {
+  id: string;
+  @read
+  publicKey: PublicKey;
+
+  function constructor (id: string) {
+    this.id = id;
+    this.publicKey = ctx.publicKey;
+  }
+}
+  `)
+
+  await c.create(['id1'])
+
+  const record = await c.record('id1').get()
+  expect(record.data.id).toEqual('id1')
+  expect(record.data.publicKey).toEqual({
+    kty: 'EC',
+    crv: 'secp256k1',
+    alg: 'ES256K',
+    use: 'sig',
+    x: expect.any(String),
+    y: expect.any(String),
   })
 })
 

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -94,10 +94,7 @@ export class ClientRequest {
 
     const jsonBody = this.req.data ? JSON.stringify(this.req.data) : ''
     const cachedSignature = this.signatureCache[jsonBody]
-    // It takes time to send a request,
-    // so we want the signature to be valid at least 30s from now.
-    const cacheTimeTolerance = 30 * 1000
-    if (cachedSignature && cachedSignature.timeMs > Date.now() + cacheTimeTolerance) {
+    if (cachedSignature && cachedSignature.timeMs > Date.now()) {
       t = cachedSignature.timeMs
       sig = cachedSignature.sig
     } else {

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -88,8 +88,8 @@ export class ClientRequest {
 
   private getSignature = async (extraTimeMs: number) => {
     if (!this.signer) return ''
-    let t
 
+    let t: number
     let sig: SignerResponse
 
     const jsonBody = this.req.data ? JSON.stringify(this.req.data) : ''

--- a/packages/client/src/Client.ts
+++ b/packages/client/src/Client.ts
@@ -1,22 +1,26 @@
 
 import { AxiosError, AxiosRequestConfig } from 'axios'
 import { createError, createErrorFromAxiosError } from './errors'
-import { BasicValue, Request, RequestParams, Sender, SenderResponse, Signer } from './types'
+import { BasicValue, Request, RequestParams, Sender, SenderResponse, Signer, SignerResponse } from './types'
 
 export interface ClientConfig {
   clientId: string
   baseURL: string
 }
 
+type SignatureCache = Record<string, { timeMs: number, sig: SignerResponse }>
+
 export class Client {
   private sender: Sender
   signer?: Signer
   private config?: ClientConfig
+  private signatureCache: SignatureCache
 
   constructor(sender: Sender, signer?: Signer, config?: ClientConfig) {
     this.sender = sender
     this.signer = signer
     this.config = config
+    this.signatureCache = {}
   }
 
   request = (req: Request): ClientRequest => {
@@ -25,7 +29,7 @@ export class Client {
       method: req.method,
       params: parseParams(req.params),
       data: req.data,
-    }, this.signer, this.config)
+    }, this.signatureCache, this.signer, this.config)
   }
 }
 
@@ -35,13 +39,15 @@ export class ClientRequest {
   private sender: Sender
   private signer?: Signer
   private config?: ClientConfig
+  private signatureCache: SignatureCache
 
-  constructor(sender: Sender, req: Request, signer?: Signer, config?: ClientConfig) {
+  constructor(sender: Sender, req: Request, signatureCache: SignatureCache, signer?: Signer, config?: ClientConfig) {
     this.aborter = new AbortController()
     this.req = req
     this.sender = sender
     this.signer = signer
     this.config = config
+    this.signatureCache = signatureCache
   }
 
   abort = () => {
@@ -49,11 +55,11 @@ export class ClientRequest {
   }
 
   /* Sending a request to the server. */
-  send = async (withAuth?: boolean): Promise<SenderResponse> => {
+  send = async (withAuth?: boolean, sigExtraTimeMs?: number): Promise<SenderResponse> => {
     try {
       const req = this.req as AxiosRequestConfig
       if (this.signer && withAuth) {
-        const sig = await await this.getSignature()
+        const sig = await this.getSignature(sigExtraTimeMs || 0)
         if (sig) {
           if (!req.headers) req.headers = {}
           req.headers['X-Polybase-Signature'] = sig
@@ -80,11 +86,35 @@ export class ClientRequest {
     }
   }
 
-  private getSignature = async () => {
+  private getSignature = async (extraTimeMs: number) => {
     if (!this.signer) return ''
-    const t = Math.round(Date.now() * 1000)
-    const sig = await this.signer(`${t}.${this.req.data ? JSON.stringify(this.req.data) : ''}`, this.req)
-    if (!sig) return null
+    let t
+
+    let sig: SignerResponse
+
+    const jsonBody = this.req.data ? JSON.stringify(this.req.data) : ''
+    const cachedSignature = this.signatureCache[jsonBody]
+    // It takes time to send a request,
+    // so we want the signature to be valid at least 30s from now.
+    const cacheTimeTolerance = 30 * 1000
+    if (cachedSignature && cachedSignature.timeMs > Date.now() + cacheTimeTolerance) {
+      t = cachedSignature.timeMs
+      sig = cachedSignature.sig
+    } else {
+      t = Date.now() + extraTimeMs
+      const s = await this.signer(`${t}.${jsonBody}`, this.req)
+      if (!s) return null
+
+      sig = s
+
+      if (extraTimeMs > 0) {
+        this.signatureCache[jsonBody] = {
+          timeMs: t,
+          sig: s,
+        }
+      }
+    }
+
     const h = [
       'v=0',
       `t=${t}`,

--- a/packages/client/src/Record.ts
+++ b/packages/client/src/Record.ts
@@ -42,7 +42,9 @@ export class CollectionRecord<T> {
   }
 
   get = async (): Promise<CollectionRecordResponse<T>> => {
-    const res = await this.client.request(this.request()).send(false)
+    const doesNotNeedAuth = await this.collection.isPubliclyAccessible()
+    const needsAuth = !doesNotNeedAuth
+    const res = await this.client.request(this.request()).send(needsAuth)
     return res.data
   }
 

--- a/packages/client/src/Record.ts
+++ b/packages/client/src/Record.ts
@@ -42,8 +42,8 @@ export class CollectionRecord<T> {
   }
 
   get = async (): Promise<CollectionRecordResponse<T>> => {
-    const doesNotNeedAuth = await this.collection.isPubliclyAccessible()
-    const needsAuth = !doesNotNeedAuth
+    const isPubliclyAccessible = await this.collection.isPubliclyAccessible()
+    const needsAuth = !isPubliclyAccessible
     const sixtyMinutes = 60 * 60 * 1000
     const res = await this.client.request(this.request()).send(needsAuth, sixtyMinutes)
     return res.data

--- a/packages/client/src/Record.ts
+++ b/packages/client/src/Record.ts
@@ -44,7 +44,8 @@ export class CollectionRecord<T> {
   get = async (): Promise<CollectionRecordResponse<T>> => {
     const doesNotNeedAuth = await this.collection.isPubliclyAccessible()
     const needsAuth = !doesNotNeedAuth
-    const res = await this.client.request(this.request()).send(needsAuth)
+    const sixtyMinutes = 60 * 60 * 1000
+    const res = await this.client.request(this.request()).send(needsAuth, sixtyMinutes)
     return res.data
   }
 

--- a/packages/client/src/__tests__/Collection.spec.ts
+++ b/packages/client/src/__tests__/Collection.spec.ts
@@ -206,3 +206,73 @@ test('.create() sends a create request', async () => {
 
   expect(result.data).toEqual({ id: 'id1', age: 30 })
 })
+
+test('.isPubliclyAccessible() returns true if collection is @public', async () => {
+  const meta = {
+    code: `
+      @public
+      collection col {}
+    `,
+    ast: JSON.stringify((await parse(`
+      @public
+      collection col {}
+    `, ''))[1]),
+  }
+
+  sender.mockResolvedValue({
+    status: 200,
+    data: {
+      data: meta,
+    },
+  })
+
+  const c = new Collection('col', client)
+  expect(await c.isPubliclyAccessible()).toBe(true)
+  expect(sender).toHaveBeenCalledTimes(1)
+})
+
+test('.isPubliclyAccessible() returns true if collection is @read', async () => {
+  const meta = {
+    code: `
+      @read
+      collection col {}
+    `,
+    ast: JSON.stringify((await parse(`
+      @read
+      collection col {}
+    `, ''))[1]),
+  }
+
+  sender.mockResolvedValue({
+    status: 200,
+    data: {
+      data: meta,
+    },
+  })
+
+  const c = new Collection('col', client)
+  expect(await c.isPubliclyAccessible()).toBe(true)
+  expect(sender).toHaveBeenCalledTimes(1)
+})
+
+test('.isPubliclyAccessible() returns false if collection is not @public or @read', async () => {
+  const meta = {
+    code: `
+      collection col {}
+    `,
+    ast: JSON.stringify((await parse(`
+      collection col {}
+    `, ''))[1]),
+  }
+
+  sender.mockResolvedValue({
+    status: 200,
+    data: {
+      data: meta,
+    },
+  })
+
+  const c = new Collection('col', client)
+  expect(await c.isPubliclyAccessible()).toBe(false)
+  expect(sender).toHaveBeenCalledTimes(1)
+})

--- a/packages/client/src/__tests__/Record.spec.ts
+++ b/packages/client/src/__tests__/Record.spec.ts
@@ -24,10 +24,28 @@ test('record is instance of CollectionRecord', () => {
 })
 
 test('get request is sent to client', async () => {
+  const meta = {
+    code: `
+      @public
+      collection col1 {}
+    `,
+    ast: JSON.stringify((await parse(`
+      @public
+      collection col1 {}
+    `, ''))[1]),
+  }
+
+  sender.mockResolvedValueOnce({
+    status: 200,
+    data: {
+      data: meta,
+    },
+  })
+
   const data = {
     id: 'id1',
   }
-  sender.mockResolvedValue({
+  sender.mockResolvedValueOnce({
     data: {
       data,
     },
@@ -35,7 +53,7 @@ test('get request is sent to client', async () => {
   const d = new CollectionRecord('id1', collection, client, register)
   await d.get()
 
-  expect(sender).toHaveBeenCalledTimes(1)
+  expect(sender).toHaveBeenCalledTimes(2)
   expect(sender).toHaveBeenCalledWith({
     ...defaultRequest,
     url: '/collections/col1/records/id1',


### PR DESCRIPTION
We cache read signatures for 60 minutes.
Cache lives as long as the Client object.