### PR TITLE
ENG-721: Allow calls with 0 parameters to skip passing []

### DIFF
--- a/packages/client/e2e/e2e.spec.ts
+++ b/packages/client/e2e/e2e.spec.ts
@@ -762,6 +762,35 @@ test('delete', async () => {
   })
 })
 
+test('allow calls with zero parameters to skip passing []', async () => {
+  const namespace = `${prefix}-zero-param-calls`
+  
+  const c = await createCollection(s, namespace, `
+    @public
+    collection ZeroParamCallCol {
+      id: string;
+      name: string;
+
+      constructor(id: string, name: string) {
+        this.id = id;
+        this.name = name;
+      }
+
+      del() {
+        selfdestruct();
+      }
+    }
+  `)
+
+  await c.create(['id1', 'Timmy'])
+  await c.record('id1').call('del')
+
+  expect(await c.record('id1').get()).toMatchObject({
+    data: null,
+    block: null
+  })
+})
+
 test('bytes', async () => {
   const namespace = `${prefix}-bytes`
 

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -104,7 +104,7 @@ export class Collection<T> {
     return hasPublicDirective || hasTypeDirective
   }
 
-  create = async (args: CallArgs): Promise<CollectionRecordResponse<T>> => {
+  create = async (args: CallArgs = []): Promise<CollectionRecordResponse<T>> => {
     const [res, ast] = await Promise.all([
       this.client.request({
         url: `/collections/${encodeURIComponent(this.id)}/records`,

--- a/packages/client/src/Collection.ts
+++ b/packages/client/src/Collection.ts
@@ -105,6 +105,10 @@ export class Collection<T> {
   }
 
   create = async (args: CallArgs = []): Promise<CollectionRecordResponse<T>> => {
+    if (!Array.isArray(args)) {
+      throw new TypeError('invalid argument: `args` must be an array')
+    }
+
     const [res, ast] = await Promise.all([
       this.client.request({
         url: `/collections/${encodeURIComponent(this.id)}/records`,


### PR DESCRIPTION
Note: Functionality was already working;

Changes:
  - added default value for `args` in `Collection`'s `create`. 
  - added test for calling zero parameter functions without passing in `[]`.