### PR TITLE
Fix encodeBase64 not handling uint8 arrays beyond ~100kB

### DIFF
--- a/packages/client/src/util.ts
+++ b/packages/client/src/util.ts
@@ -22,7 +22,13 @@ export function getCollectionShortNameFromId(id: string): string {
 }
 
 export function encodeBase64(value: Uint8Array): string {
-  return btoa(String.fromCharCode.apply(null, value as unknown as number[]))
+  // safe base64 encoding which works even with larger arrays
+  // see https://github.com/mathiasbynens/base64/issues/13
+  // solution inspired by https://github.com/WebReflection/uint8-to-base64/blob/master/esm/index.js
+  const output = [];
+  for (let i = 0; i < value.length; i++)
+    output.push(String.fromCharCode(value[i]));
+  return btoa(output.join(''));
 }
 
 export function decodeBase64(value: string): Uint8Array {


### PR DESCRIPTION
Motivation: When I was trying to upload bigger data to polybase it was failing with a `RangeError: Maximum call stack size exceeded` which turned out to be caused by the `encodeBase64()` function which apparently wasn't able to handle data bigger than ~100kB.

This PR reimplements the `encodeBase64()` in a safer way which works with bigger arrays without issues, even beyond 1MB - not sure if there's an upper bound, I guess a proper solution for bigger data would be to stream/chunk it somehow which would require designing a whole new API call, nevertheless, this solution is an improvement respective to the current implementation and it was already enough for my usecase

more info on the issue e.g. here: https://github.com/mathiasbynens/base64/issues/13

How to test: Try creating a colletion with a buffer field containing a data item of more than 100kB:

```typescript
const pb = new Polybase({
  defaultNamespace: 'mynamespace',
})
await pb
  .collection('MyCollection')
  .create([Array(1_000_000).fill(0)])
```